### PR TITLE
fix(to_acceptable_name): simpler and better way to detect empty input

### DIFF
--- a/bin/to_acceptable_name
+++ b/bin/to_acceptable_name
@@ -5,24 +5,11 @@
 
 declare -ir MAX_LENGTH=255
 
-{
-    # Overkill stuff to replace empty input with a “_”,
-    # because obviously a file cannot have an empty name.
-    unset -v found_something
-    while IFS='' read -r line
-    do
-        if [ "$line" ]
-        then
-            printf '%s\n' "$line"
-            found_something=1
-        fi
-    done
-    
-    if [ ! "$found_something" ]
-    then
-        echo '_'
-    fi
-} | sed 's,:, -,g' \
+# Overkill stuff to replace empty input with a “_”,
+# because obviously a file cannot have an empty name.
+data=$(cat -)
+
+sed 's,:, -,g' <<< "${data:-_}" \
     | tr ' /' '__' \
     | tr -d '"?[:cntrl:]' \
     | tr "'"' #' '_' \

--- a/test_scripts/to_acceptable_name.sh
+++ b/test_scripts/to_acceptable_name.sh
@@ -119,5 +119,8 @@ do
     _inp=${_params[i]}
     _out=${_params[i + 1]}
     
+    # “<<<” adds a newline. The script should work with *and*
+    # without it, hence the “printf + pipe” version.
     test "$("$THE_SCRIPT" <<< "$_inp")" = "$_out"
+    test "$(printf '%s' "$_inp" | "$THE_SCRIPT")" = "$_out"
 done


### PR DESCRIPTION
Omg. `<<<` adds a newline but `mmeta | …` not necessarily, so `to_acceptable_name`’s overkill `while` loop was screwed.