### PR TITLE
fix(bandcamp): allow “look_for_existing_cover” to scan deeper

### DIFF
--- a/lib/bandcamp_functions.sh
+++ b/lib/bandcamp_functions.sh
@@ -448,14 +448,17 @@ function process_one_source_file {
 function look_for_existing_cover {
     local maybe_cover
     
-    for maybe_cover in {cover,COVER}.{jpg,jpeg,png,gif,JPG,JPEG,PNG,GIF}
-    do
-        if [ -r "$maybe_cover" ]
-        then
-            printf '%s\n' "$maybe_cover"
-            return 0
-        fi
-    done
+    maybe_cover=$(
+        find . -regextype 'posix-extended' -type f -readable \
+                -iregex '.*/cover\.(png|jpe?g|gif)' \
+                -print -quit
+    )
+    
+    if [ "$maybe_cover" ]
+    then
+        printf '%s\n' "$maybe_cover"
+        return 0
+    fi
     
     return 1
 }

--- a/test_scripts/bandcamp/look_for_existing_cover.sh
+++ b/test_scripts/bandcamp/look_for_existing_cover.sh
@@ -36,9 +36,10 @@ ok=(
     COVER.GIF
     cover.GIF
     COVER.gif
+    
+    cOvEr.jpg
 )
 not_ok=(
-    cOvEr.jpg
     foo.jpg
     foo.JPG
     foo.png
@@ -52,7 +53,7 @@ do
     
     sta=0
     out=$(look_for_existing_cover) || sta=$?
-    test "$out" = "$name"
+    test "$out" = ./"$name"
     test "$sta" -eq 0
     
     rm -- "${name:?}"
@@ -69,3 +70,12 @@ do
     
     rm -- "${name:?}"
 done
+
+# Cover within a directory.
+mkdir -p some/dir/
+touch some/dir/cover.jpg
+
+sta=0
+out=$(look_for_existing_cover) || sta=$?
+test "$out" = ./some/dir/cover.jpg
+test "$sta" -eq 0


### PR DESCRIPTION
The old version only accepts covers found at the root of the ZIP.