### PR TITLE
feat(bandcamp): accept more types of non-music file for the “other/” dir

### DIFF
--- a/lib/bandcamp_functions.sh
+++ b/lib/bandcamp_functions.sh
@@ -712,7 +712,7 @@ function clean_all_file_names {
 
 function find_non_music_files {
     find . -regextype 'posix-extended' -type f \
-            -iregex '.*\.(pdf|png|jpe?g|gif|txt|html|md)|.*/readme.*' \
+            -iregex '.*\.(pdf|png|jpe?g|gif|txt|html|md|adoc|mov|avi|mp4|mkv)|.*/readme.*' \
             -not -iregex '.*/cover\.(png|jpe?g|gif)' \
             -not -name "${COVER_LQ_BASENAME:?}" \
             -print0

--- a/test_scripts/bandcamp/find_non_music_files.sh
+++ b/test_scripts/bandcamp/find_non_music_files.sh
@@ -22,6 +22,9 @@ declare -A still_needs_to_be_found=(
     [b.jpeg]=1
     [c.png]=1
     [d.gif]=1
+    [e.MOV]=1
+    [f.avi]=1
+    [g.adoc]=1
 )
 
 unset -v to_create
@@ -38,6 +41,7 @@ to_create=(
     
     foo.txt BAR.PDF jrijri.md
     a.jpg b.jpeg c.png d.gif
+    e.MOV f.avi g.adoc
     
     osef.mp3 nope.flac OSEF.MP3 NOPE.FLAC
 )


### PR DESCRIPTION
I wasn’t expecting https://rivalrivalrival.bandcamp.com/album/crypt-of-the-necrodancer-the-melody-mixes to contain a movie.

- [x] Read my own code in the diff.
- [x] The documentation is up to date.
- [x] Tests are still OK and updated if it makes sense.