### PR TITLE
fix(metadata): remove leading zeroes from track number

### DIFF
--- a/lib/bandcamp_functions.sh
+++ b/lib/bandcamp_functions.sh
@@ -655,7 +655,7 @@ function process_one_source_file {
     # Lowercase.
     type=${type,,}
     
-    track_number=$("$MMETA" '%T' "$src" | cut -d '/' -f 1)
+    track_number=$("$MMETA" '%T' "$src" | cut -d '/' -f 1 | sed 's/^0*//')
     # Fallback: Try to get the track number from the filename.
     : "${track_number:=$(
         # Get the first group of numbers.


### PR DESCRIPTION
“lib/bandcamp_functions.sh: line 658: 08: value too great for base (error token is "08")”

DESCRIPTION_HERE

- [x] Read my own code in the diff.
- [x] The documentation is up to date.
- [x] Tests are still OK and updated if it makes sense.