### PR TITLE
fix: capitasong’s “I’m”; to_acceptable_name greek tiny boost

### DIFF
--- a/bin/capitasong
+++ b/bin/capitasong
@@ -2,6 +2,7 @@
 
 # Read song titles through arguments
 # and capitalize them correctly in most cases.
+# Also does a bit of cleaning for common ugly things.
 
 # Rules taken from http://aitech.ac.jp/~ckelly/midi/help/caps.html
 # Old weird link, not guaranteed to work forever,
@@ -181,7 +182,10 @@ do
         # Roman numerals.
         # https://stackoverflow.com/a/10441405
         s/\bM{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})\b/\U&/ig
+        # “mix” is far more common as a word than as a number.
         s/\bMIX\b/Mix/g
+        # The “m” of “I’m” is not a number either.
+        s/\bI'"'"'M\b/I'"'"'m/g
         # Conflict with French contractions.
         s/\b[DLM]'"'"'/\L&/g
         
@@ -203,12 +207,13 @@ do
         # First word:
         s/^([^[:alnum:]]*)([[:alnum:]()])/\1\u\2/
         # Last word:
-        s/([[:alnum:]()]*)([^[:alnum:]]*)$/\u\1\2/
+        s/([[:alnum:]()'"'"']*)([^[:alnum:]]*)$/\u\1\2/
         # In both cases:
         # • We skip non-alnum characters, to allow final punctuation
         #   and the like.
         # • We allow “(foo)” prefixes and suffixes by counting
         #   parentheses as parts of the words, somewhat.
+        # We also allow apostrophe-based contractions for the last word.
     ' <<< "$title"
 done
 

--- a/bin/to_acceptable_name
+++ b/bin/to_acceptable_name
@@ -298,7 +298,7 @@ sed 's,:, -,g' <<< "${data:-_}" \
         # into lowercase beforehand)
         s/α/a/g
         s/β/b/g
-        s/γ/g/g
+        s/[γɣ]/g/g
         s/δ/d/g
         s/ε/e/g
         s/ζ/z/g
@@ -313,7 +313,7 @@ sed 's,:, -,g' <<< "${data:-_}" \
         s/ο/o/g
         s/π/p/g
         s/ρ/r/g
-        s/σ/s/g
+        s/[σς]/s/g
         s/τ/t/g
         s/υ/y/g
         s/φ/f/g

--- a/test_scripts/capitasong.sh
+++ b/test_scripts/capitasong.sh
@@ -141,6 +141,13 @@ _params=(
     '2nde'      '2de'
     '2nds'      '2ds'
     '2ndes'     '2des'
+    
+    "i'm you"       "I'm You"
+    "yes i'm you"   "Yes I'm You"
+    "yes i'm"       "Yes I'm"
+    "i've you"      "I've You"
+    "yes i've you"  "Yes I've You"
+    "yes i've"      "Yes I've"
 )
 
 for ((i = 0;  i < ${#_params[@]} - 1;  i += 2))

--- a/test_scripts/to_acceptable_name.sh
+++ b/test_scripts/to_acceptable_name.sh
@@ -26,6 +26,8 @@ _params=(
     œæŒÆ                    oeaeoeae
     'ΨΥΧΙΚΗ ΑΠΟΣΥΝΘΕΣΗ'     psychikh_aposynthesh
     'Ψυχικη Αποσυνθεση'     psychikh_aposynthesh
+    γɣ                      gg
+    ßσς                     ssss
     
     'a%b`c°d'   'a_b_c_d'
     


### PR DESCRIPTION
* Roman numerals broke “I’m”.
* Tiny additions to Greek support for transliteration.

- [x] Read my own code in the diff.
- [x] The documentation is up to date.
- [x] Tests are still OK and updated if it makes sense.
