### PR TITLE
feat(eyed3): add “album artist” tag to MP3s if the option is supported

### DIFF
--- a/bin/bandcamp
+++ b/bin/bandcamp
@@ -142,7 +142,7 @@ fi
 # Grmbl, eyeD3 keeps breaking backwards compatibility
 # and their changelog is not *that* informative.
 unset -v EYED3_ENCODING_OPT
-if eyeD3 --help | grep -q -- '--set-encoding[= \t]'
+if eyeD3 --help 2> /dev/null | grep -q -- '--set-encoding[= \t]'
 then
     readonly EYED3_ENCODING_OPT=('--set-encoding=utf8')
 else
@@ -151,6 +151,15 @@ fi
 debug 'EYED3_ENCODING_OPT=(%s )' "$(
     printf ' %q' "${EYED3_ENCODING_OPT[@]}"
 )"
+
+# I’m not sure that option was there when I started.
+if eyeD3 --help 2> /dev/null | grep -q -- '--album-artist[= \t]'
+then
+    readonly EYED3_ALBUMARTIST_SUPPORT=1
+else
+    readonly EYED3_ALBUMARTIST_SUPPORT=''
+fi
+debug 'EYED3_ALBUMARTIST_SUPPORT=%q' "$EYED3_ALBUMARTIST_SUPPORT"
 
 
 readonly DIR_TEMP=$(

--- a/lib/bandcamp_functions.sh
+++ b/lib/bandcamp_functions.sh
@@ -617,6 +617,13 @@ function retag_mp3 {
         --genre="${t[genre]}"
     )
     
+    if [[ $EYED3_ALBUMARTIST_SUPPORT && ${t[albumartist]} ]]
+    then
+        optns+=(
+            --album-artist="${t[albumartist]}"
+        )
+    fi
+    
     safe_year=$(tr -cd '0-9' <<< "${t[year]}")
     
     if [ "$safe_year" ] && [ "$safe_year" -gt 0 ]

--- a/test_scripts/bandcamp/tag_mp3.sh
+++ b/test_scripts/bandcamp/tag_mp3.sh
@@ -8,6 +8,7 @@ set -evx
 
 unset -v EYED3_ENCODING_OPT
 EYED3_ENCODING_OPT=(foo bar plop)
+EYED3_ALBUMARTIST_SUPPORT=1
 
 
 callfile=$(mktemp "${TMPDIR:-/tmp}"/bandcamp-test-tag-mp3-XXXXXXXX)
@@ -30,6 +31,7 @@ function eyeD3 {
         --track=42
         --track-total=98
         --genre=Genre
+        --album-artist='Foo Alb Art'
         -Y 1899
         
         dest.mp3
@@ -49,15 +51,20 @@ _status=0
 
 # Should exit the subshell because of missing args.
 # The “true” should therefore not be executed.
-! ( retag_mp3;                  true )
-! ( retag_mp3 foo;              true )
-! ( retag_mp3 '' bar;           true )
-! ( retag_mp3 foo bar plop;     true )
-! ( retag_mp3 foo bar plop '';  true )
+if  ( retag_mp3;                  true ) ||
+    ( retag_mp3 foo;              true ) ||
+    ( retag_mp3 '' bar;           true ) ||
+    ( retag_mp3 foo bar plop;     true ) ||
+    ( retag_mp3 foo bar plop '';  true )
+then
+    : Should have failed.
+    exit 1
+fi
 
 unset -v meta
 declare -A meta=(
     [artist]='a b'
+    [albumartist]='Foo Alb Art'
     [album]='C d Ef'
     [maxtrack]=98
     [genre]=Genre
@@ -100,6 +107,7 @@ function eyeD3 {
         --track=42
         --track-total=98
         --genre=Genre
+        --album-artist='Foo Alb Art'
         
         dest.mp3
     )
@@ -117,6 +125,7 @@ function eyeD3 {
 unset -v meta
 declare -A meta=(
     [artist]='a b'
+    [albumartist]='Foo Alb Art'
     [album]='C d Ef'
     [maxtrack]=98
     [genre]=Genre


### PR DESCRIPTION
I was wondering why White Ward’s “False Light” album was mutilated and spread among 297529 artist names in Kodi… 😒
I have no idea since when EyeD3 supports `--album-artist`. I think it wasn’t there when I started writing this stuff.
I used to download everything in FLAC so these kinds of things escaped my attention a bit, but now I mostly use MP3s again.

- [x] Read my own code in the diff.
- [x] The documentation is up to date.
- [x] Tests are still OK and updated if it makes sense.
