### PR TITLE
feat(genres): get genre via MusicBrainz tags

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{*.ad,*.adoc,*.asciidoc,.asciidoctorconfig}]
+ij_asciidoc_blank_lines_after_header = 1
+ij_asciidoc_blank_lines_keep_after_header = 1
+ij_asciidoc_formatting_enabled = false
+ij_asciidoc_one_sentence_per_line = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+
+### VS Code ###
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 FROM debian:11
 
-RUN apt-get update && apt-get -y install bash locales eyed3 flac rsync unzip imagemagick mawk ffmpeg file
+RUN apt-get update && apt-get -y install \
+    bash locales file mawk \
+    eyed3 flac ffmpeg \
+    rsync unzip \
+    imagemagick \
+    jq
 
 RUN sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 COPY bin /bc/bin

--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,7 @@ The files are then *stored* in a configurable location, in neatly named *directo
 
 It should work with pretty much *any ZIP archive that contains MP3 or FLAC files*, actually. <<sample-exec,See example below.>>
 
-Some other scripts there are dependencies of the `bandcamp` one, but can also be used on their own for various purposes.
+Some other scripts, here, are dependencies of the `bandcamp` one, but can also be used on their own for various purposes.
 
 
 == Getting started
@@ -326,7 +326,7 @@ To make the script run without any interaction, use a no-op or any idle-ish comm
 [CAUTION]
 ====
 The editor _must_ block the execution flow, so that you’re able to edit the metadata, save, and close it _before_ the rest of the script runs.
-Some editors, like Visual Studio Code, tend to launch themselves in the background – much like when appending `&` to a command – on their own, and may therefore be impossible to use properly in this context.
+Some editors, like Visual Studio Code, tend to launch themselves in the background – much like when appending `&` to a command – on their own, and may require tweaks to be used properly in this context.
 Some have options to avoid this: use `code --wait` instead of just `code` for Visual Studio Code and you should be OK.
 ====
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,15 @@
 = Bandcamp, etc. (`bandcampetc`)
-:toc:
-:toclevels: 0
+:toc: preamble
+:toclevels: 2
 
-Scripts to keep music tidy. The main one extracts and cleans files from https://bandcamp.com/[Bandcamp] and Amazon Music downloads. It should work with pretty much any ZIP archive that contains MP3 or FLAC files, actually. <<sample-exec,See example below.>>
+Scripts to keep music tidy.
+
+The main script (`bandcamp`) can be used to *extract* and *clean* files (allow to review and easily edit some *metadata* fields) from https://bandcamp.com/[Bandcamp] and Amazon Music downloads.
+The files are then *stored* in a configurable location, in neatly named *directories*.
+
+It should work with pretty much *any ZIP archive that contains MP3 or FLAC files*, actually. <<sample-exec,See example below.>>
+
+Some other scripts there are dependencies of the `bandcamp` one, but can also be used on their own for various purposes.
 
 
 == Getting started
@@ -15,47 +22,77 @@ Scripts to keep music tidy. The main one extracts and cleans files from https://
 
 .`~/.bashrc`
 [source, bash]
---
+----
 PATH+=':~/bin/bandcampetc/bin/'
 export PATH
---
+----
 
-WARNING: Make sure you adapt the `~/bin/bandcampetc/bin/` path of the example according to where you saved this project.
+[WARNING]
+====
+Make sure you adapt the `~/bin/bandcampetc/bin/` path of the example according to where you saved this project.
+====
 
 
 === Dependencies
 
 The `bandcamp` script relies on:
 
-[horizontal]
-Bash version ≥ 4::  Because associative arrays. Should already be OK except maybe on old Macs.
+Bash · version ≥ 4.3::  Because associative arrays and variables declared with `-n`.
+Should already be OK on most machines.
 
-`eyeD3`::       Manipulate MP3 metadata. Note that the software’s package is generally called `eyed3`.
-                These guys often break backward compatibility… I adapted my commands at least to versions `0.6.18` (Ubuntu 16) and `0.7.10` (Debian 9). <<contact-section,Tell me>> if you get “unrecognized arguments” errors.
+`eyeD3`::
+Manipulate MP3 metadata. Note that the software’s package is generally called `eyed3`.
+These guys often break backward compatibility…
+I adapted my commands firstly to version `0.6.18` (Ubuntu 16) and later to `0.7.10` (Debian 9).
+<<contact-section,Tell me>> if you get “unrecognized arguments” errors.
 
-`metaflac`::    Manipulate FLAC metadata. Bundled with the `flac` package.
+`metaflac`::
+Manipulate FLAC metadata.
+Bundled with the `flac` package.
 
-`rsync`::       “A fast, versatile, remote (and local) file-copying tool.”
+`rsync`::
+“A fast, versatile, remote (and local) file-copying tool.”
 
-`unzip`::       Decompress ZIP archives.
+`unzip`::
+Decompress ZIP archives.
 
-ImageMagick::   To manipulate cover art. (`imagemagick` package.)
+ImageMagick::
+To manipulate cover art. (`imagemagick` package.)
 
-`awk`::         “Pattern scanning and processing language.” GNU’s `gawk` implementation recommended, but the minimal implementation `mawk` does the job.
+`awk`::
+“Pattern scanning and processing language.”
+GNU’s `gawk` implementation recommended, but the minimal implementation `mawk` does the job.
 
-`geany`::       … as a recommended simple text editor to revise music metadata. You can use <<config-editor,any other editor by changing a constant’s value>> in `config/bandcamp.sh`.
+`geany`::
+… as a recommended simple text editor to revise music metadata.
+You can use <<config-editor,any other editor by changing a constant’s value>> in `config/bandcamp.sh`.
 
-`ffmpeg` or `avconv`::  For FLAC → MP3 conversions. *(Optional, see <<convert-config,the config section>>.)*
+`ffmpeg` or `avconv`::
+For FLAC → MP3 conversions. +
+*(Optional, see <<convert-config,the config section>>.)*
 
-`file`::        Installed on most distributions, but missing from some Docker images.
-                The package is also called `file`.
+`file`::
+Installed on most distributions, but missing from some Docker images.
+The package is also called `file`.
 
+`curl` · version ≥ 7.67.0::
+To send HTTP requests to the MusicBrainz API. +
+*(Optional, for the `getgenre` script.)*
+
+`jq`::
+To process the data sent back by the MusicBrainz API.
+Version{nbsp}``1.6`` is recommended, but it _may_ work with older ones. +
+*(Optional, for the `getgenre` script.)*
+
+[TIP]
+====
 On Ubuntu and Debian machines, this should be enough to get everything:
 
 [source, bash]
 ----
-$ sudo apt-get install eyed3 flac rsync unzip imagemagick gawk geany ffmpeg file
+$ sudo apt install eyed3 flac rsync unzip imagemagick gawk geany ffmpeg file jq curl
 ----
+====
 
 
 == Contents
@@ -67,10 +104,15 @@ The main script, at least from my point of view. When you download music from Ba
 This script can be run from anywhere (it has no importance) without argument.
 
 1. It will look for ZIPs in `~/Downloads/`, `~/Téléchargements/`, `~/Descargas/`, `~/Загрузки/`… You can also give ZIPs directly as arguments to the script.
+
 2. For each ZIP that contains MP3 or FLAC files, the files will be extracted.
+
 3. You will be offered the possibility to edit the music’s metadata in a text editor.
+
 4. The files will be tagged and named according to the cleaned version of the metadata.
-5. If the album is in FLAC format and if the `CONVERT_TO_MP3` constant has been set to a non empty value, an MP3 version of the record will be generated alongside the FLAC version.
+
+5. If the album is in FLAC format and if the `CONVERT_TO_MP3` constant has been set to a non-empty value, an MP3 version of the record will be generated alongside the FLAC version.
+
 6. The original ZIP will be discarded.
 
 See `bandcamp -h` for help.
@@ -94,8 +136,43 @@ Le Chien de Ta Mère Est Gros
 [NOTE]
 ====
 Many conventions exist.
-I used stuff from http://aitech.ac.jp/~ckelly/midi/help/caps.html. (That weird link might become dead or point to something unrelated someday. Use with caution.)
+I used stuff from +http://aitech.ac.jp/~ckelly/midi/help/caps.html+.
+(That weird link might become dead or point to something unrelated someday.
+Use with caution.)
 ====
+
+
+=== `getgenre`
+
+Try to get a musical genre from tags found on MusicBrainz.
+Can try to target a specific release or (on purpose or as a fallback) an artist itself.
+
+By default, only the best tag is printed out, but `-n, --number` can be used to ask for more.
+In such cases, the best tags will come first.
+
+.Sample calls
+====
+.Specific album, two results
+[source, bash]
+----
+  $ getgenre -a 'sigur ros' -r kveikur -n 2
+Post-rock
+Rock
+----
+
+.Artist as a whole, single result, long option name
+[source, bash]
+----
+  $ getgenre --artist 'negura bunget'
+Black metal
+----
+====
+
+.Getting help
+[source, bash]
+----
+$ getgenre -h
+----
 
 
 === `covers`
@@ -229,10 +306,12 @@ unset -v EDITOR
 #readonly EDITOR=(mousepad)
 #readonly EDITOR=(leafpad)
 #readonly EDITOR=(gedit)
+#readonly EDITOR=(code --new-window --wait)
 readonly EDITOR=(geany -i)
 ----
 
-The commented out lines give you examples for other editors than Geany. Uncomment one of them (while commenting the others), or write your own assignment.
+The commented out lines give you examples for other editors than Geany.
+Uncomment one of them (while commenting the others), or write your own assignment.
 
 [NOTE]
 ====
@@ -244,12 +323,21 @@ I use an indexed array rather than a dumb string to make the script more robust:
 To make the script run without any interaction, use a no-op or any idle-ish command as an editor: `readonly EDITOR=(:)`
 ====
 
+[CAUTION]
+====
+The editor _must_ block the execution flow, so that you’re able to edit the metadata, save, and close it _before_ the rest of the script runs.
+Some editors, like Visual Studio Code, tend to launch themselves in the background – much like when appending `&` to a command – on their own, and may therefore be impossible to use properly in this context.
+Some have options to avoid this: use `code --wait` instead of just `code` for Visual Studio Code and you should be OK.
+====
+
 
 == Tests
 
 === Unit tests
 
-I love trying to do unit testing in Bash. Just run `./run_tests.sh` and a bunch of commands will be executed. The first failure stops the execution (`set -e`) and you should be able to see what failed in the output.
+I love trying to do unit testing in Bash.
+Just run `./run_tests.sh` and a bunch of commands will be executed.
+The first failure stops the execution (`set -e`) and you should be able to see what failed in the output.
 
 If everything works as intended, the output should end with a message like:
 
@@ -270,7 +358,8 @@ $ ./run_tests.sh test_scripts/mmeta.sh test_scripts/setcover/gettype.sh
 
 === Integration tests
 
-The `run_integration_tests.sh` script runs the unit tests as well as the `bandcamp` script in a Debian Docker container. Nothing fancy for now as I’m no Docker expert, but it allowed me to improve stuff already.
+The `run_integration_tests.sh` script runs the unit tests as well as the `bandcamp` script in a Debian Docker container.
+Nothing fancy for now as I’m no Docker expert, but it allowed me to improve stuff already.
 
 
 [#sample-exec]

--- a/bin/bandcamp
+++ b/bin/bandcamp
@@ -9,10 +9,11 @@ function bandcamp_help {
 
   For every ZIP file in the download directory or given as argument:
     1. take the content,
-    2. Optional: convert it to MP3 if it is a FLAC record,
-    3. find a cover if there are none,
-    4. apply the cover to the files, and
-    5. store all this in the music directory.
+    2. show the metadata for potential auto and manual fixes,
+    3. Optional: convert it to MP3 if it is a FLAC record,
+    4. find a cover if there are none,
+    5. apply a lower-quality version of the cover to the files, and
+    6. store all this in the music directory.
 
   Note that since all you need are ZIPs containing MP3 or FLAC files,
   this can work for lots of downloads (e.g., Amazon Music),
@@ -50,12 +51,12 @@ do
     case "$opt" in
         d)  PRINT_DEBUG=1;;
         c)  CONVERT_TO_MP3=1;;
-        
+
         h)
             bandcamp_help
             exit 0
             ;;
-        
+
         *)
             exit 1
             ;;
@@ -64,7 +65,9 @@ done
 shift $((OPTIND - 1))
 
 
-readonly PRINT_DEBUG CONVERT_TO_MP3
+# shellcheck disable=SC2034 # Mostly used in “bandcamp_functions.sh”.
+readonly PRINT_DEBUG
+readonly CONVERT_TO_MP3
 
 readonly MMETA=${SCR_DIR}/mmeta
 readonly COVERS=${SCR_DIR}/covers
@@ -72,19 +75,24 @@ readonly LQCOVER=${SCR_DIR}/create-lq-cover
 readonly SETCOVER=${SCR_DIR}/setcover
 readonly CAPITASONG=${SCR_DIR}/capitasong
 readonly RENAME=${SCR_DIR}/to_acceptable_name
+readonly GETGENRE=${SCR_DIR}/getgenre
 
 # Check if everything is set.
 # Quotes thrown in the mix to avoid DoS via globbing.
 : "${EDITOR:?} ${MMETA:?} ${COVERS:?} ${LQCOVER:?}"
-: "${SETCOVER:?} ${CAPITASONG:?} ${RENAME:?} ${CONV:?}"
+: "${SETCOVER:?} ${CAPITASONG:?} ${RENAME:?} ${GETGENRE:?} ${CONV:?}"
 : "${MMETA_PLACEHOLDER:?} ${COVER_LQ_BASENAME:?}"
 : "${CONVERTED_MP3_RATE:?}"
 
 # Formatting, with overkill stuff
 # for platforms that do not support this.
+# shellcheck disable=SC2034 # Used in logging functions.
 readonly TBOLD=$(tput -T"${TERM:-xterm}" bold 2> /dev/null)
+# shellcheck disable=SC2034 # Used in logging functions.
 readonly TYEL=$(tput -T"${TERM:-xterm}" setaf 3 2> /dev/null)
+# shellcheck disable=SC2034 # Used in logging functions.
 readonly TRED=$(tput -T"${TERM:-xterm}" setaf 1 2> /dev/null)
+# shellcheck disable=SC2034 # Used in logging functions.
 readonly TNORM=$(tput -T"${TERM:-xterm}" sgr0 2> /dev/null)
 
 
@@ -99,9 +107,9 @@ DEPS=(
     "$COVERS"
     "$SETCOVER"
     "$CAPITASONG"
-    
+
     "${EDITOR[0]}"
-    
+
     eyeD3
     metaflac
     rsync
@@ -171,6 +179,7 @@ then
     exit 3
 fi
 
+# shellcheck disable=SC2034 # Used in functions defined elsewhere.
 readonly METAFILE=${DIR_TEMP}/bandcamp_metafile.txt
 
 
@@ -187,13 +196,13 @@ do
     then
         continue
     fi
-    
+
     # Normalize, and avoid getting mime types
     # like “inode/symlink” at the ZIP test.
     archive=$(readlink -f -- "$archive")
-    
+
     log 'Inspecting “%s”...' "$archive"
-    
+
     # Is it a valid ZIP? Note that empty ones might fail the test, as
     # they count as “application/octet-stream”, but of course there
     # is no music in empty archives, so /shrug.
@@ -202,24 +211,24 @@ do
         log 'Not a valid ZIP? Skipping.'
         continue
     fi
-    
+
     # Is there music in the ZIP?
     if ! mp3_or_flac_in_zip "$archive"
     then
         log 'No MP3 or FLAC here. Skipping.'
         continue
     fi
-    
+
     # Clean temp dir.
     rm -fr -- "${DIR_TEMP:?}"/*
     # Put the archive in it.
     cp -- "$archive" "${DIR_TEMP:?}"/ || continue
-    
+
     if ! process_one_music_zip "$archive"
     then
         err 'Could not handle this archive. Skipping.'
     fi
-    
+
     echo
 done
 

--- a/bin/getgenre
+++ b/bin/getgenre
@@ -1,0 +1,206 @@
+#! /usr/bin/env bash
+
+readonly BASE_URL='https://musicbrainz.org/ws/2'
+readonly QUERY_AND=' AND '
+declare -ri API_VERSION=2
+declare -ri DEFAULT_NUMBER=1
+readonly COMMON_PARAMETERS="fmt=json&limit=1&version=${API_VERSION}"
+
+# ========
+
+print_help() {
+    cat << _HELP_
+
+  Utility to fetch musical genres from the web.
+  Currently relies on MusicBrainz tags, giving a higher
+  priority to those with a high “count”.
+  Note that these may refer to things that are not genres,
+  so the resulting suggestions must be taken with a bit of caution.
+
+  If only an artist name is provided, an artist search is done.
+  If both an artist name and a release name are provided, we first look
+  for a release (technically a “release group”), and use an artist search
+  as fallback if no tags are found.
+
+  Options:
+    -a A, --artist A    Use “A” as “part of the artist name” search query criterion.
+    -r R, --release R   Use “R” as “part of the release name” search query criterion.
+    -n N, --number N    List at most N results, one per line, with the best ones first.
+                        Defaults to ${DEFAULT_NUMBER}.
+    -h, --help          Print this help message and exit.
+
+  Exits with 0 status if at least one tag could be found.
+
+_HELP_
+}
+
+# Make sure we’re ready to start (after command parsing).
+checks() {
+    local error
+    if ! type jq &> /dev/null
+    then
+        error=1
+        printf '%s: Error: “jq” program not found.\n' "$(basename "$0")" >&2
+    fi
+    if ! type curl &> /dev/null
+    then
+        error=1
+        printf '%s: Error: “curl” program not found.\n' "$(basename "$0")" >&2
+    fi
+    if [[ -z $opt_artist ]]
+    then
+        error=1
+        print_help
+        printf '%s: Error: Gave no artist name.\n' "$(basename "$0")" >&2
+    fi
+
+    if [[ $error ]]
+    then
+        exit 1
+    fi
+}
+
+# $@    Extra arguments
+curl_with_options() {
+    curl --no-progress-meter "$@"
+}
+
+# $1    String to encode
+uri_encode() {
+    jq -rR '@uri' <<< "$1"
+}
+
+# https://lucene.apache.org/core/4_3_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Escaping_Special_Characters
+#
+# $1    String to escape
+escape_for_apache_lucene() {
+    sed '
+        s,[][+&|!(){}^"~*?:\\/-],\\&,g
+    ' <<< "$1"
+}
+
+# Get .foo[0].tags, sort by count, get the tag names,
+# and keep the first results according to “$opt_number”.
+#
+# $1    JSON
+# $2    Name of root field holding results (“artists”,  “release-groups”…).
+get_tags_from() {
+    jq -r "
+        limit(
+            ${opt_number:?};
+            .\"${2:?Field name}\"[0].tags |
+                    sort_by(-.count)[].name // empty
+        )
+    " <<< "$1" 2> /dev/null
+}
+
+# Print the result and exit with a 0 status if we’re happy with
+# what we got.
+# The found tags are capitalized (sentence case).
+# Do nothing if no result.
+#
+# $1    Potential result. May be multiline (one tag per line).
+if_result_print_and_exit() {
+    if [[ $1 ]]
+    then
+        # shellcheck disable=SC2001 # Hard to do with “${…/…/…}”.
+        sed 's/.*/\u&/' <<< "$1"
+        exit 0
+    fi
+}
+
+# Read the command and set a bunch of global option-related
+# “opt_*” variables.
+#
+# $@    Arguments of the script itself, forwarded as-is.
+parse_command() {
+    local word
+    # Defaults
+    # shellcheck disable=SC2154 # https://github.com/koalaman/shellcheck/issues/1500
+    unset -v "${!opt_@}"
+    declare -ig opt_number=$DEFAULT_NUMBER
+    while (($# > 0))
+    do
+        word=$1
+        shift
+        case $word in
+            -a|--artist)
+                opt_artist=${1:?No artist given after “$word”.}
+                shift
+                ;;
+
+            -r|--release)
+                opt_release=${1:?No release given after “$word”.}
+                shift
+                ;;
+
+            -n|--number)
+                opt_number=${1:?No number given after “$word”.}
+                shift
+                if ((opt_number < 1))
+                then
+                    printf '%s: Error: Asked for fewer than one result.\n' "$(basename "$0")" >&2
+                    exit 1
+                fi
+                ;;
+
+            -h|--help)
+                print_help
+                exit 0
+                ;;
+
+            *)
+                print_help
+                printf '%s: Error: Unrecognized argument: %q\n' "$(basename "$0")" "$word" >&2
+                exit 2
+                ;;
+        esac
+    done
+}
+
+look_for_release() {
+    local query
+    query+="artistname:$(escape_for_apache_lucene "$opt_artist")"
+    query+=$QUERY_AND
+    query+="releasegroup:$(escape_for_apache_lucene "$opt_release")"
+
+    local url="$BASE_URL/release-group/"
+    url+="?${COMMON_PARAMETERS}"
+    url+="&query=$(uri_encode "$query")"
+
+    local json
+    json=$(curl_with_options "$url")
+    local result
+    result=$(get_tags_from "$json" release-groups)
+
+    if_result_print_and_exit "$result"
+}
+
+look_for_artist() {
+    local query
+    query+="artistname:$(escape_for_apache_lucene "$opt_artist")"
+
+    local url="$BASE_URL/artist/"
+    url+="?${COMMON_PARAMETERS}"
+    url+="&query=$(uri_encode "$query")"
+
+    local json
+    json=$(curl_with_options "$url")
+    local result
+    result=$(get_tags_from "$json" artists)
+
+    if_result_print_and_exit "$result"
+}
+
+# ========
+
+parse_command "$@"
+checks
+if [[ $opt_release ]]
+then
+    look_for_release
+fi
+look_for_artist
+
+# If we got there, it means that we could find nothing.
+exit 1

--- a/config/bandcamp.sh
+++ b/config/bandcamp.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034 # This file is meant to be sourced; no need to export stuff.
 
 # Set music directory. Just remove these lines and
 # hard-code a path if you want to use something else:
@@ -70,5 +70,9 @@ readonly MMETA_PLACEHOLDER='Unknown'
 readonly COVER_LQ_BASENAME='cover_lq.jpg'
 # Given to Lame when creating MP3 files from HQ files.
 readonly CONVERTED_MP3_RATE=128k
+# Maximal number of tags fetched from the MusicBrainz API
+# when trying to get genre info. Using an overkill value can yield
+# out-of-topic tags such as city names and the like.
+declare -ri NUMBER_OF_MUSICBRAINZ_TAGS=3
 # Set to non empty value to activate debug logs.
 PRINT_DEBUG=''

--- a/config/bandcamp.sh
+++ b/config/bandcamp.sh
@@ -1,3 +1,6 @@
+#! /usr/bin/env bash
+# shellcheck disable=SC2034
+
 # Set music directory. Just remove these lines and
 # hard-code a path if you want to use something else:
 #
@@ -10,7 +13,7 @@ do
     then
         break
     fi
-    
+
     # Try in lowercase.
     if [ -d "${one_dir,,}" ]
     then
@@ -23,6 +26,7 @@ readonly DIR_M=$one_dir
 # Set to non empty value to convert FLAC files to MP3.
 # I used to keep everything in both formats, and then ran out of space.
 # Now I convert to MP3 on the fly when putting music on my phone or whatever.
+# Edit: Now I only choose FLAC for releases that seem to deserve it.
 CONVERT_TO_MP3=''
 
 # EDITOR is a text editor command with options, in an indexed array.
@@ -40,6 +44,7 @@ unset -v EDITOR
 #readonly EDITOR=(mousepad)
 #readonly EDITOR=(leafpad)
 #readonly EDITOR=(gedit)
+#readonly EDITOR=(code --new-window --wait)
 readonly EDITOR=(geany -i)
 
 # avconv replaced ffmpeg in Ubuntu's repositories. The options I use exist

--- a/it/run.sh
+++ b/it/run.sh
@@ -5,7 +5,7 @@ function clean_between_runs {
 }
 
 
-set -evx
+set -ex
 
 # Go to project.
 cd /bc/

--- a/it/subscripts/flac_with_conversion.sh
+++ b/it/subscripts/flac_with_conversion.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 
 cp -v it/assets/fake_album_flac_version.zip ~/Downloads/

--- a/it/subscripts/flac_without_conversion.sh
+++ b/it/subscripts/flac_without_conversion.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 
 cp -v it/assets/fake_album_flac_version.zip ~/Downloads/

--- a/it/subscripts/mp3.sh
+++ b/it/subscripts/mp3.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 
 cp -v it/assets/fake_album_mp3_version.zip ~/Downloads/

--- a/lib/bandcamp_functions.sh
+++ b/lib/bandcamp_functions.sh
@@ -152,7 +152,11 @@ function clean_hierarchy {
 # $1    Path to ZIP archive.
 # Exits with 0 status iff it contains a “.mp3” or “.flac” file.
 function mp3_or_flac_in_zip {
-    unzip -l "${1:?No archive given.}" | grep -iqE '.\.(flac|mp3)$'
+    local archive=${1:?No archive given.}
+    (
+        set -o pipefail
+        unzip -l "$archive" | grep -iqE '.\.(flac|mp3)$'
+    )
 }
 
 

--- a/test_scripts/bandcamp/apply_cover_if_we_got_one.sh
+++ b/test_scripts/bandcamp/apply_cover_if_we_got_one.sh
@@ -1,12 +1,16 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
 
 
-! ( apply_cover_if_we_got_one; true )
+if ( apply_cover_if_we_got_one; true )
+then
+    : Should have failed
+    exit 1
+fi
 
 COVER_LQ_BASENAME=poire
 SETCOVER=mock_setcover

--- a/test_scripts/bandcamp/clean_all_file_names.sh
+++ b/test_scripts/bandcamp/clean_all_file_names.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
@@ -34,7 +34,11 @@ tdir=$(mktemp -d "${TMPDIR:-/tmp}"/bandcamp-clean-test-XXXXXXXX)
 
 cd "${tdir:?}"
 
-! ( clean_all_file_names; true )
+if ( clean_all_file_names; true )
+then
+    : Should have failed
+    exit 1
+fi
 
 mkdir -p storage/{foo,bar,plop}/
 touch storage/foo/'jRæŸ=r (foo1) bar'.flac

--- a/test_scripts/bandcamp/clean_hierarchy.sh
+++ b/test_scripts/bandcamp/clean_hierarchy.sh
@@ -1,16 +1,32 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
 
 
-( clean_hierarchy;          true ) && exit 1
-( clean_hierarchy '';       true ) && exit 1
-( clean_hierarchy '' foo;   true ) && exit 1
+if ( clean_hierarchy;          true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( clean_hierarchy '';       true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( clean_hierarchy '' foo;   true )
+then
+    : Should have failed
+    exit 1
+fi
 
-! clean_hierarchy /does/not/exist/of/course
+if clean_hierarchy /does/not/exist/of/course
+then
+    : Should have failed
+    exit 1
+fi
 
 tdir=$(mktemp -d "${TMPDIR:-/tmp}"/bandcamp-test-cleaning-XXXXXXXX)
 test -d "${tdir:?}"
@@ -18,9 +34,21 @@ test -d "${tdir:?}"
 mkdir -p "$tdir"/foo/bar/plop/{aa,.hbb} "$tdir"/foo/yo
 touch "$tdir"/foo/bar/plop/{aa/,.hbb/,}{f1,f2,f3,.hf1,.hf2}
 
-! clean_hierarchy "$tdir"/foo
-! clean_hierarchy "$tdir"/foo/bar/plop
-! clean_hierarchy "$tdir"/foo/bar/plop/aa
+if clean_hierarchy "$tdir"/foo
+then
+    : Should have failed
+    exit 1
+fi
+if clean_hierarchy "$tdir"/foo/bar/plop
+then
+    : Should have failed
+    exit 1
+fi
+if clean_hierarchy "$tdir"/foo/bar/plop/aa
+then
+    : Should have failed
+    exit 1
+fi
 
 clean_hierarchy "$tdir"/foo/bar
 clean_hierarchy "$tdir"

--- a/test_scripts/bandcamp/clean_hierarchy_if_needed.sh
+++ b/test_scripts/bandcamp/clean_hierarchy_if_needed.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh

--- a/test_scripts/bandcamp/compute_final_dir_path.sh
+++ b/test_scripts/bandcamp/compute_final_dir_path.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
@@ -12,7 +12,11 @@ RENAME=${SCR_DIR}/../../bin/to_acceptable_name
 test -x "$RENAME"
 
 # No music directory set.
-! ( compute_final_dir_path; true )
+if ( compute_final_dir_path; true )
+then
+    : Should have failed
+    exit 1
+fi
 
 DIR_M=poire/tourte
 

--- a/test_scripts/bandcamp/convert_to_mp3.sh
+++ b/test_scripts/bandcamp/convert_to_mp3.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
@@ -35,9 +35,21 @@ CONVERTED_MP3_RATE=154k
 
 # Should exit the subshell because of missing args.
 # The “true” should therefore not be executed.
-( convert_to_mp3;           true ) && exit 1
-( convert_to_mp3 foo;       true ) && exit 1
-( convert_to_mp3 '' bar;    true ) && exit 1
+if ( convert_to_mp3;           true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( convert_to_mp3 foo;       true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( convert_to_mp3 '' bar;    true )
+then
+    : Should have failed
+    exit 1
+fi
 
 unset -v _called _ok
 convert_to_mp3 src.flac dest.mp3
@@ -47,6 +59,10 @@ test "$_ok"
 _status=1
 
 unset -v _called _ok
-! convert_to_mp3 src.flac dest.mp3
+if convert_to_mp3 src.flac dest.mp3
+then
+    : Should have failed
+    exit 1
+fi
 test "$_called"
 test "$_ok"

--- a/test_scripts/bandcamp/display.sh
+++ b/test_scripts/bandcamp/display.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh

--- a/test_scripts/bandcamp/find_non_music_files.sh
+++ b/test_scripts/bandcamp/find_non_music_files.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh

--- a/test_scripts/bandcamp/get_artist_for_track.sh
+++ b/test_scripts/bandcamp/get_artist_for_track.sh
@@ -1,14 +1,26 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
 
 
-! ( get_artist_for_track; true )
-! ( get_artist_for_track foo; true )
-! ( get_artist_for_track 1; true )
+if ( get_artist_for_track; true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( get_artist_for_track foo; true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( get_artist_for_track 1; true )
+then
+    : Should have failed
+    exit 1
+fi
 
 
 unset -v meta

--- a/test_scripts/bandcamp/get_num_list.sh
+++ b/test_scripts/bandcamp/get_num_list.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh

--- a/test_scripts/bandcamp/get_record_format.sh
+++ b/test_scripts/bandcamp/get_record_format.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh

--- a/test_scripts/bandcamp/look_for_existing_cover.sh
+++ b/test_scripts/bandcamp/look_for_existing_cover.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh

--- a/test_scripts/bandcamp/music_file_precleaning.sh
+++ b/test_scripts/bandcamp/music_file_precleaning.sh
@@ -1,12 +1,16 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
 
 
-! ( music_file_precleaning; true )
+if ( music_file_precleaning; true )
+then
+    : Should have failed
+    exit 1
+fi
 
 tdir=$(mktemp -d "${TMPDIR:-/tmp}"/bandcamp-test-preclean-XXXXXXXX)
 cd "${tdir:?}"

--- a/test_scripts/bandcamp/music_in_zip.sh
+++ b/test_scripts/bandcamp/music_in_zip.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
@@ -13,6 +13,9 @@ function unzip {
         printf '%s\n' "$_data"
     fi
 }
+
+
+: Yes
 
 for _data in 'seljpsjpbse
 peljséjpseéjp épet ldpe
@@ -34,6 +37,9 @@ eélpedtpéelp plédtelép'
 do
     mp3_or_flac_in_zip foo
 done
+
+
+: Nope
 
 for _data in 'seljpsjpbse
 peljséjpseéjp épet ldpe
@@ -65,9 +71,17 @@ peljséjpseéjp épet ldpe
 eétledpételdé
 eélpedtpéelp plédtelép'
 do
-    ! mp3_or_flac_in_zip foo
+    if mp3_or_flac_in_zip foo
+    then
+        : Should have failed
+        exit 1
+    fi
 done
 
 # No argument.
 _data=foo.mp3
-! mp3_or_flac_in_zip
+if (mp3_or_flac_in_zip; true)
+then
+    : Should have failed
+    exit 1
+fi

--- a/test_scripts/bandcamp/my_renamer.sh
+++ b/test_scripts/bandcamp/my_renamer.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh

--- a/test_scripts/bandcamp/print_metafile.sh
+++ b/test_scripts/bandcamp/print_metafile.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh

--- a/test_scripts/bandcamp/print_metafile.sh
+++ b/test_scripts/bandcamp/print_metafile.sh
@@ -11,11 +11,11 @@ function mock_mmeta {
         '2 %T\n '*)
             echo 03/009
             ;;
-        
+
         '3 -e %t '*)
             echo 'a a b a a'
             ;;
-        
+
         *)
             exit 1
             ;;
@@ -40,6 +40,7 @@ meta=(
     [album]='lsi dldldl lsi'
     [year]=1998
     [genre]='lsi nrnrnr lsi'
+    [musicbrainztags]=$'Foo bar\nPlop yo'
 )
 
 test "$(print_metafile_content osef meta)" = "$(
@@ -65,6 +66,7 @@ ARTIST      = lsi lsi lsi
 ALBUMARTIST = lsi uyuyu lsi
 ALBUM       = lsi dldldl lsi
 YEAR        = 1998
+# Best MusicBrainz tags: “Foo bar” “Plop yo”
 GENRE       = lsi nrnrnr lsi
 
 # <Track #> = <Title>
@@ -96,11 +98,11 @@ function mock_mmeta {
         '2 %T\n '*)
             echo 03/009
             ;;
-        
+
         '3 -e %t '*)
             # No title available, say nothing.
             ;;
-        
+
         *)
             exit 1
             ;;

--- a/test_scripts/bandcamp/process_and_move_existing_cover.sh
+++ b/test_scripts/bandcamp/process_and_move_existing_cover.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
@@ -18,7 +18,11 @@ tdir=$(mktemp -d "${TMPDIR:-/tmp}"/bandcamp-cover-test-XXXXXXXX)
 
 cd "${tdir:?}"
 
-! ( process_and_move_existing_cover; true )
+if ( process_and_move_existing_cover; true )
+then
+    : Should have failed
+    exit 1
+fi
 
 : Basic case.
 mkdir -p storage/{mp3,flac} some/random/location

--- a/test_scripts/bandcamp/process_one_music_zip.sh
+++ b/test_scripts/bandcamp/process_one_music_zip.sh
@@ -1,12 +1,16 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
 
 
-! ( process_one_music_zip; true )
+if ( process_one_music_zip; true )
+then
+    : Should have failed
+    exit 1
+fi
 
 COVERS=mock_covers
 

--- a/test_scripts/bandcamp/process_one_source_file.sh
+++ b/test_scripts/bandcamp/process_one_source_file.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
@@ -21,12 +21,36 @@ function mock_mmeta {
 
 MMETA=mock_mmeta
 
-! ( process_one_source_file;            true )
-! ( process_one_source_file a;          true )
-! ( process_one_source_file a b;        true )
-! ( process_one_source_file '' b c;     true )
-! ( process_one_source_file a '' c;     true )
-! ( process_one_source_file '' '' c;    true )
+if ( process_one_source_file;            true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( process_one_source_file a;          true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( process_one_source_file a b;        true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( process_one_source_file '' b c;     true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( process_one_source_file a '' c;     true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( process_one_source_file '' '' c;    true )
+then
+    : Should have failed
+    exit 1
+fi
 
 unset -v meta
 declare -A meta=(

--- a/test_scripts/bandcamp/read_metafile.sh
+++ b/test_scripts/bandcamp/read_metafile.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
@@ -86,7 +86,11 @@ _DATA_
 # Should skip this album.
 unset -v m
 declare -A m
-! read_metafile m tracks
+if read_metafile m tracks
+then
+    : Should have failed
+    exit 1
+fi
 
 
 

--- a/test_scripts/bandcamp/retag_flac.sh
+++ b/test_scripts/bandcamp/retag_flac.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh

--- a/test_scripts/bandcamp/set_track_number.sh
+++ b/test_scripts/bandcamp/set_track_number.sh
@@ -1,14 +1,26 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
 
 
-! ( set_track_number_for_mp3;           true )
-! ( set_track_number_for_mp3 foo;       true )
-! ( set_track_number_for_mp3 '' bar;    true )
+if ( set_track_number_for_mp3;           true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( set_track_number_for_mp3 foo;       true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( set_track_number_for_mp3 '' bar;    true )
+then
+    : Should have failed
+    exit 1
+fi
 
 unset -v _calls
 declare -a _calls
@@ -23,15 +35,31 @@ test "${_calls[0]}" = '--to-v2.4 --no-color --track=42 foo/bar.mp3'
 
 # Should fail if tagging fails.
 function eyeD3 { false; }
-! set_track_number_for_mp3 foo/bar.mp3 42
+if set_track_number_for_mp3 foo/bar.mp3 42
+then
+    : Should have failed
+    exit 1
+fi
 
 
 : MP3 ↑ / ↓ FLAC
 
 
-! ( set_track_number_for_flac;          true )
-! ( set_track_number_for_flac foo;      true )
-! ( set_track_number_for_flac '' bar;   true )
+if ( set_track_number_for_flac;          true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( set_track_number_for_flac foo;      true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( set_track_number_for_flac '' bar;   true )
+then
+    : Should have failed
+    exit 1
+fi
 
 unset -v _calls
 declare -a _calls
@@ -46,7 +74,11 @@ test "${_calls[0]}" = '--dont-use-padding --remove-tag=TRACKNUMBER --set-tag=TRA
 
 # Should fail if tagging fails.
 function metaflac { false; }
-! set_track_number_for_flac foo/bar.flac 42
+if set_track_number_for_flac foo/bar.flac 42
+then
+    : Should have failed
+    exit 1
+fi
 
 
 : Generic function.
@@ -84,7 +116,11 @@ done
 for path in lsilsi lsi.txt FOO.PDF ./././.
 do
     unset -v _called_mp3 _called_flac
-    ! set_track_number_for_file "$path" 42
+    if set_track_number_for_file "$path" 42
+    then
+        : Should have failed
+        exit 1
+    fi
     test -z "$_called_mp3"
     test -z "$_called_flac"
 done

--- a/test_scripts/bandcamp/tag_mp3.sh
+++ b/test_scripts/bandcamp/tag_mp3.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/bandcamp_functions.sh
 . lib/bandcamp_functions.sh
@@ -80,7 +80,11 @@ _status=1
 
 > "$callfile"
 _expected_artist='a b'
-! retag_mp3 dest.mp3 42 'lsilsi jrejre' meta
+if retag_mp3 dest.mp3 42 'lsilsi jrejre' meta
+then
+    : Should have failed
+    exit 1
+fi
 test "$(cat "$callfile")" = ok
 
 : With custom artist.

--- a/test_scripts/capitasong.sh
+++ b/test_scripts/capitasong.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 readonly THE_SCRIPT=bin/capitasong
 

--- a/test_scripts/getgenre.sh
+++ b/test_scripts/getgenre.sh
@@ -1,0 +1,136 @@
+#! /usr/bin/env bash
+
+set -ex
+
+readonly THE_SCRIPT=bin/getgenre
+
+curl() {
+    if [[ $* = *${_EXPECTED_MOCKED_CURL_ARGS_PATTERN}* ]]
+    then
+        printf '%s\n' "$_MOCKED_CURL_TEST_DATA"
+    else
+        : Wrong arguments
+        exit 1
+    fi
+}
+export -f curl
+
+artist_data=$(
+    cat << '_JSON_'
+{
+  "artists": [
+    {
+      "tags": [
+        {
+          "count": 2,
+          "name": "jazz"
+        },
+        {
+          "count": 3,
+          "name": "jazz fusion"
+        },
+        {
+          "count": -1,
+          "name": "oklahoma"
+        },
+        {
+          "count": 1,
+          "name": "free jazz"
+        }
+      ]
+    }
+  ]
+}
+_JSON_
+)
+
+release_data=$(
+    cat << '_JSON_'
+{
+  "release-groups": [
+    {
+      "tags": [
+        {
+          "count": 2,
+          "name": "jazz"
+        },
+        {
+          "count": 3,
+          "name": "jazz fusion"
+        },
+        {
+          "count": -1,
+          "name": "oklahoma"
+        },
+        {
+          "count": 1,
+          "name": "free jazz"
+        }
+      ]
+    }
+  ]
+}
+_JSON_
+)
+
+export _EXPECTED_MOCKED_CURL_ARGS_PATTERN='/ws/2/artist/*plop'
+
+export _MOCKED_CURL_TEST_DATA
+_MOCKED_CURL_TEST_DATA=$artist_data
+
+
+: Missing parameters
+
+if stderr=$("$THE_SCRIPT" -r foo 2>&1 > /dev/null)
+then
+    : Should have failed
+    exit 1
+fi
+
+[[ ${stderr,,} = *'no artist name'* ]]
+
+
+: Artist search
+
+test "$("$THE_SCRIPT" -a plop)" = 'Jazz fusion'
+test "$("$THE_SCRIPT" -a plop -n 3)" = "$(
+    cat << '_EXPECTED_'
+Jazz fusion
+Jazz
+Free jazz
+_EXPECTED_
+)"
+
+
+: Release search
+
+_MOCKED_CURL_TEST_DATA=$release_data
+export _EXPECTED_MOCKED_CURL_ARGS_PATTERN='/ws/2/release-group/*artistname%3Aplop*releasegroup%3Ayo'
+
+test "$("$THE_SCRIPT" -a plop -r yo)" = 'Jazz fusion'
+test "$("$THE_SCRIPT" -a plop -r yo -n 3)" = "$(
+    cat << '_EXPECTED_'
+Jazz fusion
+Jazz
+Free jazz
+_EXPECTED_
+)"
+
+
+: Fail for release, fall back on artist
+
+# Using the artist-focused data will, as a side effect,
+# force release search to fail, as the release-focused JSON paths
+# will yield nothing there.
+_MOCKED_CURL_TEST_DATA=$artist_data
+# Lenient pattern since we’ll be handling two requests this time.
+export _EXPECTED_MOCKED_CURL_ARGS_PATTERN='/ws/2/*plop'
+
+test "$("$THE_SCRIPT" -a plop -r yo)" = 'Jazz fusion'
+test "$("$THE_SCRIPT" -a plop -r yo -n 3)" = "$(
+    cat << '_EXPECTED_'
+Jazz fusion
+Jazz
+Free jazz
+_EXPECTED_
+)"

--- a/test_scripts/mmeta.sh
+++ b/test_scripts/mmeta.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 readonly THE_SCRIPT=bin/mmeta
 

--- a/test_scripts/setcover/get_flac_cover_front_block_nums.sh
+++ b/test_scripts/setcover/get_flac_cover_front_block_nums.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/setcover_functions.sh
 . lib/setcover_functions.sh
@@ -18,8 +18,16 @@ function metaflac {
 }
 
 
-! ( get_flac_cover_front_block_nums; true )
-! ( get_flac_cover_front_block_nums ''; true )
+if ( get_flac_cover_front_block_nums; true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( get_flac_cover_front_block_nums ''; true )
+then
+    : Should have failed
+    exit 1
+fi
 
 
 : No pic.

--- a/test_scripts/setcover/gettype.sh
+++ b/test_scripts/setcover/gettype.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/setcover_functions.sh
 . lib/setcover_functions.sh

--- a/test_scripts/setcover/tag_flac.sh
+++ b/test_scripts/setcover/tag_flac.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 # shellcheck source=../../lib/setcover_functions.sh
 . lib/setcover_functions.sh
@@ -25,10 +25,26 @@ function metaflac {
 }
 
 
-! ( f_tag_flac;         true )
-! ( f_tag_flac '';      true )
-! ( f_tag_flac '' '';   true )
-! ( f_tag_flac '' foo;  true )
+if ( f_tag_flac;         true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( f_tag_flac '';      true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( f_tag_flac '' '';   true )
+then
+    : Should have failed
+    exit 1
+fi
+if ( f_tag_flac '' foo;  true )
+then
+    : Should have failed
+    exit 1
+fi
 
 
 _list=$(

--- a/test_scripts/to_acceptable_name.sh
+++ b/test_scripts/to_acceptable_name.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -evx
+set -ex
 
 readonly THE_SCRIPT=bin/to_acceptable_name
 


### PR DESCRIPTION
After one more evening spent fetching genres on RateYouMusic manually (with their horrendous auto-playing videos and everything), I FINALLY decided to start reading the MusicBrainz API documentation and using it.

The new feature is also usable on its own (`getgenre` script).

NB: This requires `curl` and `jq`. (Those may come in handy later for other things, though.)

➕ Cleanup because some of that code is growing old and makes me shameful regarding some aspects.

- [x] Read my own code in the diff.
- [x] The documentation is up to date.
- [x] Tests are still OK and updated if it makes sense.
