### PR TITLE
fix(bandcamp): unreliable “is there music in that ZIP”

### DIFF
--- a/lib/bandcamp_functions.sh
+++ b/lib/bandcamp_functions.sh
@@ -153,10 +153,12 @@ function clean_hierarchy {
 # Exits with 0 status iff it contains a “.mp3” or “.flac” file.
 function mp3_or_flac_in_zip {
     local archive=${1:?No archive given.}
-    (
-        set -o pipefail
-        unzip -l "$archive" | grep -iqE '.\.(flac|mp3)$'
-    )
+    # Got intermittent failures and ditched the pipe for an intermediate variable.
+    # See:
+    # https://unix.stackexchange.com/questions/782524/inconsistent-unzip-l-grep-q-results-with-pipefail/782525
+    local listing
+    listing=$(unzip -l "$archive")
+    grep -iqE '[^/]\.(flac|mp3)$' <<< "$listing"
 }
 
 


### PR DESCRIPTION
`unzip` sometimes got killed and caused the script to believe there was no FLAC nor MP3 in random ZIPs.

🌍 https://unix.stackexchange.com/questions/782524/inconsistent-unzip-l-grep-q-results-with-pipefail/782525

- [x] Read my own code in the diff.
- [x] The documentation is up to date.
- [x] Tests are still OK and updated if it makes sense.